### PR TITLE
Fix prefix on HELP and TYPE tags + don't force {}

### DIFF
--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -224,8 +224,9 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Format output
-	regex1, _ := regexp.Compile("^" + prefix + "\\w*{.*}\\s+")
-	regex2, _ := regexp.Compile("^" + prefix + "\\w*{.*}\\s+[0-9|\\.]*")
+	regex1, _ := regexp.Compile("^" + prefix + "\\w*(?:{.*})?\\s+")
+	regex2, _ := regexp.Compile("^" + prefix + "\\w*(?:{.*})?\\s+[0-9|\\.]*")
+	rexexSharp, _ := regexp.Compile("^(# *(?:TYPE|HELP) +)")
 
 	var formatedOutput string
 	scanner := bufio.NewScanner(strings.NewReader(output))
@@ -235,7 +236,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 		if metric == "" {
 			// Do nothing
 		} else if metric[0:1] == "#" {
-			formatedOutput += fmt.Sprintf("%s\n", metric)
+			formatedOutput += fmt.Sprintf("%s\n", rexexSharp.ReplaceAllString(metric, "${1}" + prefix))
 		} else {
 			metric = fmt.Sprintf("%s%s", prefix, metric)
 			metrics := regex1.FindAllString(metric, -1)


### PR DESCRIPTION
When you use "prefix" TYPE and HELP are not modified, so Prometheus returns an error.
I added a regex to replace the varaible name from this two script lines.

I also modified the original regex to allow make metricx like "name value" and don't force to add parenthesis"name{} value"

I created a small script to test this:
```
#!/bin/bash

echo "#NOTHING test_var Test var"
echo "# NOTING test_var Test var"
echo "#HELPO test_var Test var"
echo "# HELPO test_var Test var"
echo "#HELPtest_var Test var"
echo "#TYPO test_var gauge"
echo "# TYPO test_var gage"
echo "#TYPEtest_var gauge"
echo
echo
echo "#HELP test_var Test var"
echo "# HELP test_var Test var"
echo
echo
echo "#TYPE test_var gauge"
echo "# TYPE test_var gauge"
echo "test_var{} 1"
echo "test_var 1"

```


That generates this raw output:
```
#NOTHING test_var Test var
# NOTING test_var Test var
#HELPO test_var Test var
# HELPO test_var Test var
#HELPtest_var Test var
#TYPO test_var gauge
# TYPO test_var gage
#TYPEtest_var gauge


#HELP test_var Test var
# HELP test_var Test var


#TYPE test_var gauge
# TYPE test_var gauge
test_var{} 1
test_var 1
```

And this with the script wihtout prefix: `/probe?script=test_changes`
```
# HELP script_success Script exit status (0 = error, 1 = success).
# TYPE script_success gauge
script_success{} 1
# HELP script_duration_seconds Script execution time, in seconds.
# TYPE script_duration_seconds gauge
script_duration_seconds{} 0.019491
#NOTHING test_var Test var
# NOTING test_var Test var
#HELPO test_var Test var
# HELPO test_var Test var
#HELPtest_var Test var
#TYPO test_var gauge
# TYPO test_var gage
#TYPEtest_var gauge
#HELP test_var Test var
# HELP test_var Test var
#TYPE test_var gauge
# TYPE test_var gauge
test_var{} 1
test_var 1


```
And this with prefix: `/probe?prefix=my_prefix&script=test_changes`
```
# HELP script_success Script exit status (0 = error, 1 = success).
# TYPE script_success gauge
script_success{} 1
# HELP script_duration_seconds Script execution time, in seconds.
# TYPE script_duration_seconds gauge
script_duration_seconds{} 0.014736
#NOTHING test_var Test var
# NOTING test_var Test var
#HELPO test_var Test var
# HELPO test_var Test var
#HELPtest_var Test var
#TYPO test_var gauge
# TYPO test_var gage
#TYPEtest_var gauge
#HELP my_prefix_test_var Test var
# HELP my_prefix_test_var Test var
#TYPE my_prefix_test_var gauge
# TYPE my_prefix_test_var gauge
my_prefix_test_var{} 1
my_prefix_test_var 1

```